### PR TITLE
Add Luxtronik Heat Pump Controller v2 to plugin list

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -193,6 +193,7 @@ class BasePlugin:
             "IKEA-Tradfri":                 ["moroen",          "IKEA-Tradfri-plugin",                  "IKEA Tradfri",                      "master"],
             "Linky":                        ["guillaumezin",    "DomoticzLinky",                        "Linky",                             "master"],
 	    "Link-Tap":                     ["DebugBill",       "Link-Tap",                             "Link-Tap Watering System",          "master"],
+            "luxtronikex":                  ["Rouzax",          "luxtronik-domoticz-plugin-v2",         "Luxtronik-based heat pump controllers (Alpha Innotec)", "dist"],
 	    "MeteoAlarmEU":                 ["ycahome",         "MeteoAlarmEU",                         "Meteo Alarm EU RSS Reader",         "master"],
             "mikrotik-routeros":            ["mrin",            "domoticz-routeros-plugin",             "Mikrotik RouterOS",                 "master"],
             "MoonPhases":                   ["ycahome",         "MoonPhases",                           "Moon Phases",                       "master"],


### PR DESCRIPTION
Adds the Luxtronik Heat Pump Controller v2 plugin to the list.

- Author `Rouzax`, repository `luxtronik-domoticz-plugin-v2`, branch `dist`.
- `dist` is a runtime-only branch (plugin modules + README, no tests/docs/site), maintained automatically on each release, so installs stay lean.
- Domoticz plugin for Luxtronik-based heat pump controllers (Alpha Innotec and compatible): COP tracking with steady-state gating, refrigerant-circuit diagnostics, write protection, multi-instance support, and 5 languages.