### PR TITLE
Add myenergi Monitor plugin

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -198,6 +198,7 @@ class BasePlugin:
             "MoonPhases":                   ["ycahome",         "MoonPhases",                           "Moon Phases",                       "master"],
             "Domoticz-MeshCore-Plugin":     ["galadril",        "Domoticz-MeshCore-Plugin",             "MeshCore",                          "main"],
             "MQTTDiscovery":                ["emontnemery",     "domoticz_mqtt_discovery",              "MQTT discovery",                    "master"],
+            "myenergi":                     ["Rouzax",          "myenergi-domoticz-plugin",             "myenergi zappi/harvi: solar, EV, home and grid energy with counters, plus opt-in control", "dist"],
             "Onkyo":                	    ["jorgh6",          "domoticz-onkyo-plugin",                "Onkyo AV Receiver",                 "master"],
             "owrtwifi2domo":                ["enesbcs",         "owrtwifi2domo",                        "OpenWRT WiFi Presence MQTT translator","master"],
             "pyrtl433":                     ["enesbcs",         "pyrtl433",                             "RTL_433 MQTT receiver",             "master"],


### PR DESCRIPTION
Adds the [myenergi Monitor](https://github.com/Rouzax/myenergi-domoticz-plugin) plugin to the plugindata list.

Reads a myenergi system (zappi + harvi) via the cloud API and creates Domoticz devices for solar generation, EV charging, derived home consumption, grid import/export, and per-inverter power, all with real kWh counters, plus opt-in charger control (off by default).

Entry: `"myenergi": ["Rouzax", "myenergi-domoticz-plugin", "...", "dist"]` (installs the lean `dist` branch into `plugins/myenergi`).